### PR TITLE
Revert back to using prefix

### DIFF
--- a/codegen/src/main/kotlin/com/boswelja/xmldtd/codegen/DataClassGenerator.kt
+++ b/codegen/src/main/kotlin/com/boswelja/xmldtd/codegen/DataClassGenerator.kt
@@ -416,8 +416,9 @@ public class DataClassGenerator(
                         }
                         .apply {
                             if (attribute.attributeName.contains(":")) {
-                                val (_, name) = attribute.attributeName.split(":")
+                                val (prefix, name) = attribute.attributeName.split(":")
                                 addAnnotation(AnnotationSpec.builder(XmlSerialName::class)
+                                    .addMember("prefix = %S", prefix)
                                     .addMember("value = %S", name)
                                     .build())
                                 addAnnotation(AnnotationSpec.builder(SerialName::class)
@@ -455,8 +456,9 @@ public class DataClassGenerator(
                         }
                         .apply {
                             if (attribute.attributeName.contains(":")) {
-                                val (_, name) = attribute.attributeName.split(":")
+                                val (prefix, name) = attribute.attributeName.split(":")
                                 addAnnotation(AnnotationSpec.builder(XmlSerialName::class)
+                                    .addMember("prefix = %S", prefix)
                                     .addMember("value = %S", name)
                                     .build())
                                 addAnnotation(AnnotationSpec.builder(SerialName::class)

--- a/codegen/src/main/kotlin/com/boswelja/xmldtd/codegen/DataClassGenerator.kt
+++ b/codegen/src/main/kotlin/com/boswelja/xmldtd/codegen/DataClassGenerator.kt
@@ -416,9 +416,8 @@ public class DataClassGenerator(
                         }
                         .apply {
                             if (attribute.attributeName.contains(":")) {
-                                val (prefix, name) = attribute.attributeName.split(":")
+                                val (_, name) = attribute.attributeName.split(":")
                                 addAnnotation(AnnotationSpec.builder(XmlSerialName::class)
-                                    .addMember("namespace = %S", prefix)
                                     .addMember("value = %S", name)
                                     .build())
                                 addAnnotation(AnnotationSpec.builder(SerialName::class)
@@ -456,9 +455,8 @@ public class DataClassGenerator(
                         }
                         .apply {
                             if (attribute.attributeName.contains(":")) {
-                                val (prefix, name) = attribute.attributeName.split(":")
+                                val (_, name) = attribute.attributeName.split(":")
                                 addAnnotation(AnnotationSpec.builder(XmlSerialName::class)
-                                    .addMember("namespace = %S", prefix)
                                     .addMember("value = %S", name)
                                     .build())
                                 addAnnotation(AnnotationSpec.builder(SerialName::class)

--- a/codegen/src/test/kotlin/com/boswelja/xmldtd/codegen/DataClassGeneratorTest.kt
+++ b/codegen/src/test/kotlin/com/boswelja/xmldtd/codegen/DataClassGeneratorTest.kt
@@ -66,10 +66,7 @@ class DataClassGeneratorTest {
                 |@SerialName(value = "prefixes")
                 |public data class Prefixes(
                 |  @XmlElement(value = false)
-                |  @XmlSerialName(
-                |    namespace = "xml",
-                |    value = "name",
-                |  )
+                |  @XmlSerialName(value = "name")
                 |  @SerialName(value = "name")
                 |  public val name: String,
                 |  @XmlValue

--- a/codegen/src/test/kotlin/com/boswelja/xmldtd/codegen/DataClassGeneratorTest.kt
+++ b/codegen/src/test/kotlin/com/boswelja/xmldtd/codegen/DataClassGeneratorTest.kt
@@ -66,7 +66,10 @@ class DataClassGeneratorTest {
                 |@SerialName(value = "prefixes")
                 |public data class Prefixes(
                 |  @XmlElement(value = false)
-                |  @XmlSerialName(value = "name")
+                |  @XmlSerialName(
+                |    prefix = "xml",
+                |    value = "name",
+                |  )
                 |  @SerialName(value = "name")
                 |  public val name: String,
                 |  @XmlValue


### PR DESCRIPTION
Exception being thrown because of this is a bug in the `pedantic` validator. Set `pedantic = false` to work around, until the next xmlutil update