### PR TITLE
Avoid boxing PCDATA where possible

### DIFF
--- a/codegen/src/main/kotlin/com/boswelja/xmldtd/codegen/DataClassGenerator.kt
+++ b/codegen/src/main/kotlin/com/boswelja/xmldtd/codegen/DataClassGenerator.kt
@@ -46,7 +46,7 @@ public class DataClassGenerator(
     }
 
     internal fun buildFileSpec(dtd: DocumentTypeDefinition): FileSpec {
-        val generatedTypes = generateTypeSpecForElement(dtd.rootElement)
+        val generatedTypes = generateTypeSpecForElement(dtd.rootElement, mustBoxType = true)
         return FileSpec.builder(generatedTypes.rootClassName)
             .addTypes(generatedTypes.topLevelTypes)
             .addTypes(generateXmlDtdTypes(dtd.entities))

--- a/codegen/src/test/kotlin/com/boswelja/xmldtd/codegen/DataClassGeneratorTest.ss
+++ b/codegen/src/test/kotlin/com/boswelja/xmldtd/codegen/DataClassGeneratorTest.ss
@@ -86,47 +86,6 @@ import kotlin.jvm.JvmInline
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import nl.adaptivity.xmlutil.serialization.XmlElement
-import nl.adaptivity.xmlutil.serialization.XmlValue
-
-@Serializable
-@XmlElement(value = true)
-@SerialName(value = "HEADLINE")
-public data class Headline(
-  @XmlValue
-  public val content: ParsedCharacterData,
-)
-
-@Serializable
-@XmlElement(value = true)
-@SerialName(value = "BYLINE")
-public data class Byline(
-  @XmlValue
-  public val content: ParsedCharacterData,
-)
-
-@Serializable
-@XmlElement(value = true)
-@SerialName(value = "LEAD")
-public data class Lead(
-  @XmlValue
-  public val content: ParsedCharacterData,
-)
-
-@Serializable
-@XmlElement(value = true)
-@SerialName(value = "BODY")
-public data class Body(
-  @XmlValue
-  public val content: ParsedCharacterData,
-)
-
-@Serializable
-@XmlElement(value = true)
-@SerialName(value = "NOTES")
-public data class Notes(
-  @XmlValue
-  public val content: ParsedCharacterData,
-)
 
 @Serializable
 @XmlElement(value = true)
@@ -145,20 +104,20 @@ public data class Article(
   @SerialName(value = "EDITION")
   public val edition: String?,
   @XmlElement(value = true)
-  @SerialName(value = "HEADLINE")
-  public val headline: Headline,
-  @XmlElement(value = true)
-  @SerialName(value = "BYLINE")
-  public val byline: Byline,
-  @XmlElement(value = true)
-  @SerialName(value = "LEAD")
-  public val lead: Lead,
-  @XmlElement(value = true)
-  @SerialName(value = "BODY")
-  public val body: Body,
+  @SerialName(value = "NOTES")
+  public val parsedCharacterData: ParsedCharacterData,
   @XmlElement(value = true)
   @SerialName(value = "NOTES")
-  public val notes: Notes,
+  public val parsedCharacterData: ParsedCharacterData,
+  @XmlElement(value = true)
+  @SerialName(value = "NOTES")
+  public val parsedCharacterData: ParsedCharacterData,
+  @XmlElement(value = true)
+  @SerialName(value = "NOTES")
+  public val parsedCharacterData: ParsedCharacterData,
+  @XmlElement(value = true)
+  @SerialName(value = "NOTES")
+  public val parsedCharacterData: ParsedCharacterData,
 )
 
 @Serializable
@@ -182,18 +141,7 @@ package com.example.test
 import kotlin.String
 import kotlin.collections.Map
 import kotlin.jvm.JvmInline
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import nl.adaptivity.xmlutil.serialization.XmlElement
-import nl.adaptivity.xmlutil.serialization.XmlValue
-
-@Serializable
-@XmlElement(value = true)
-@SerialName(value = "parseable_data")
-public data class ParseableData(
-  @XmlValue
-  public val content: ParsedCharacterData,
-)
 
 @Serializable
 @JvmInline

--- a/codegen/src/test/kotlin/com/boswelja/xmldtd/codegen/DataClassGeneratorTest.ss
+++ b/codegen/src/test/kotlin/com/boswelja/xmldtd/codegen/DataClassGeneratorTest.ss
@@ -141,7 +141,18 @@ package com.example.test
 import kotlin.String
 import kotlin.collections.Map
 import kotlin.jvm.JvmInline
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import nl.adaptivity.xmlutil.serialization.XmlElement
+import nl.adaptivity.xmlutil.serialization.XmlValue
+
+@Serializable
+@XmlElement(value = true)
+@SerialName(value = "parseable_data")
+public data class ParseableData(
+  @XmlValue
+  public val content: ParsedCharacterData,
+)
 
 @Serializable
 @JvmInline

--- a/codegen/src/test/kotlin/com/boswelja/xmldtd/codegen/DataClassGeneratorTest.ss
+++ b/codegen/src/test/kotlin/com/boswelja/xmldtd/codegen/DataClassGeneratorTest.ss
@@ -104,20 +104,20 @@ public data class Article(
   @SerialName(value = "EDITION")
   public val edition: String?,
   @XmlElement(value = true)
-  @SerialName(value = "NOTES")
-  public val parsedCharacterData: ParsedCharacterData,
+  @SerialName(value = "HEADLINE")
+  public val headline: ParsedCharacterData,
+  @XmlElement(value = true)
+  @SerialName(value = "BYLINE")
+  public val byline: ParsedCharacterData,
+  @XmlElement(value = true)
+  @SerialName(value = "LEAD")
+  public val lead: ParsedCharacterData,
+  @XmlElement(value = true)
+  @SerialName(value = "BODY")
+  public val body: ParsedCharacterData,
   @XmlElement(value = true)
   @SerialName(value = "NOTES")
-  public val parsedCharacterData: ParsedCharacterData,
-  @XmlElement(value = true)
-  @SerialName(value = "NOTES")
-  public val parsedCharacterData: ParsedCharacterData,
-  @XmlElement(value = true)
-  @SerialName(value = "NOTES")
-  public val parsedCharacterData: ParsedCharacterData,
-  @XmlElement(value = true)
-  @SerialName(value = "NOTES")
-  public val parsedCharacterData: ParsedCharacterData,
+  public val notes: ParsedCharacterData,
 )
 
 @Serializable


### PR DESCRIPTION
Previously, anything containing PCDATA would be wrapped in its own type. Now, if there's no additional parameters or properties, the type is not boxed!